### PR TITLE
fix: peer dependency error while yarn install

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build": "tsc"
   },
   "peerDependencies": {
-    "typedoc": "0.20.16"
+    "typedoc": ">=0.20.16"
   },
   "devDependencies": {
     "@testing-library/react": "^13.3.0",


### PR DESCRIPTION
fix this error

```shell
npm ERR! Found: typedoc@0.22.18
npm ERR! node_modules/typedoc
npm ERR!   dev typedoc@"^0.22.15" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer typedoc@"0.20.16" from @mohalla-tech/typedoc-type-coverage-plugin@1.0.2
npm ERR! node_modules/@mohalla-tech/typedoc-type-coverage-plugin
npm ERR!   dev @mohalla-tech/typedoc-type-coverage-plugin@"^1.0.2" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```